### PR TITLE
Add FastAPI endpoints for managing Cloud Run auth IDs

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,62 +1,175 @@
 import os
-from typing import Set
+import secrets
+import sqlite3
+from datetime import datetime
+from typing import List, Optional
 
-from fastapi import FastAPI, Request, HTTPException
-from fastapi.responses import JSONResponse
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
 
-from google.auth import default
-from google.auth.transport.requests import AuthorizedSession
+
+DB_PATH = os.getenv("AUTH_DB_PATH", "auth_ids.db")
+ALLOWED_ORIGINS = list(
+    filter(None, (os.getenv("ALLOWED_ORIGINS", "").split(",")))
+)
+
+
+def init_db() -> None:
+    directory = os.path.dirname(DB_PATH)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS auth_ids (
+                id TEXT PRIMARY KEY,
+                label TEXT,
+                is_active INTEGER NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+
+
+def create_auth_id(label: Optional[str]) -> str:
+    auth_id = secrets.token_urlsafe(32)
+    created_at = datetime.utcnow().isoformat() + "Z"
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT INTO auth_ids (id, label, is_active, created_at) VALUES (?, ?, ?, ?)",
+            (auth_id, label, 1, created_at),
+        )
+    return auth_id
+
+
+def list_auth_ids() -> List[sqlite3.Row]:
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            "SELECT id, label, is_active, created_at FROM auth_ids ORDER BY created_at DESC"
+        ).fetchall()
+    return rows
+
+
+def get_auth_id(auth_id: str) -> Optional[sqlite3.Row]:
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT id, label, is_active, created_at FROM auth_ids WHERE id = ?",
+            (auth_id,),
+        ).fetchone()
+    return row
+
+
+def set_auth_id_status(auth_id: str, is_active: bool) -> bool:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.execute(
+            "UPDATE auth_ids SET is_active = ? WHERE id = ?",
+            (1 if is_active else 0, auth_id),
+        )
+        return cur.rowcount > 0
+
+
+def is_auth_id_valid(auth_id: str) -> bool:
+    with sqlite3.connect(DB_PATH) as conn:
+        cur = conn.execute(
+            "SELECT 1 FROM auth_ids WHERE id = ? AND is_active = 1",
+            (auth_id,),
+        )
+        return cur.fetchone() is not None
+
+
+class AuthIdResponse(BaseModel):
+    auth_id: str
+    label: Optional[str]
+    is_active: bool
+    created_at: str
+
+
+class CreateAuthIdRequest(BaseModel):
+    label: Optional[str] = None
+
+
+class VerifyRequest(BaseModel):
+    auth_id: str
+
+
+class VerifyResponse(BaseModel):
+    is_valid: bool
+
+
+def row_to_auth_response(row: sqlite3.Row) -> AuthIdResponse:
+    return AuthIdResponse(
+        auth_id=row["id"],
+        label=row["label"],
+        is_active=bool(row["is_active"]),
+        created_at=row["created_at"],
+    )
+
 
 app = FastAPI()
 
-ALLOWED_ORIGINS: Set[str] = set(filter(None, (os.getenv("ALLOWED_ORIGINS","").split(","))))
-BROKER_API_KEY = os.getenv("BROKER_API_KEY")  # Bubble（サーバー側）だけが知っている秘密値
-SA_EMAIL = os.getenv("SA_EMAIL")              # 例: broker-sa@solarnova.iam.gserviceaccount.com
-PDF_API_AUD = os.getenv("PDF_API_AUD")        # 例: https://docxexcel2pdf-...run.app
+if ALLOWED_ORIGINS:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=ALLOWED_ORIGINS,
+        allow_methods=["GET", "POST"],
+        allow_headers=["*"]
+    )
 
-# CORS（必要なOriginだけ許可）
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=list(ALLOWED_ORIGINS) if ALLOWED_ORIGINS else [],
-    allow_credentials=False,
-    allow_methods=["POST", "OPTIONS", "GET"],
-    allow_headers=["*"],
-)
+
+@app.on_event("startup")
+def startup_event() -> None:
+    init_db()
+
 
 @app.get("/healthz")
-def healthz():
+def healthz() -> dict:
     return {"ok": True}
 
-@app.post("/token")
-def issue_token(request: Request):
-    # 1) ドメイン制限（Origin もしくは Referer を軽くチェック）
-    origin = request.headers.get("origin") or request.headers.get("referer","")
-    if ALLOWED_ORIGINS:
-        if not any(origin.startswith(o) for o in ALLOWED_ORIGINS):
-            raise HTTPException(status_code=403, detail="origin not allowed")
 
-    # 2) 共有鍵チェック（ブラウザに露出しないサーバー側で付与）
-    api_key = request.headers.get("x-api-key")
-    if not BROKER_API_KEY or api_key != BROKER_API_KEY:
-        raise HTTPException(status_code=401, detail="invalid api key")
+@app.post("/auth-ids", response_model=AuthIdResponse)
+def issue_auth_id(payload: CreateAuthIdRequest) -> AuthIdResponse:
+    auth_id = create_auth_id(payload.label)
+    row = get_auth_id(auth_id)
+    return row_to_auth_response(row)
 
-    # 3) IAM Credentials API: generateIdToken で PDF API 向けのIDトークンを発行
-    if not (SA_EMAIL and PDF_API_AUD):
-        raise HTTPException(status_code=500, detail="missing env (SA_EMAIL or PDF_API_AUD)")
 
-    creds, _ = default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
-    authed = AuthorizedSession(creds)
+@app.get("/auth-ids", response_model=List[AuthIdResponse])
+def list_auth_id_endpoint() -> List[AuthIdResponse]:
+    rows = list_auth_ids()
+    return [row_to_auth_response(row) for row in rows]
 
-    url = f"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{SA_EMAIL}:generateIdToken"
-    payload = {"audience": PDF_API_AUD, "includeEmail": True}
 
-    r = authed.post(url, json=payload)
-    if r.status_code != 200:
-        raise HTTPException(status_code=502, detail=f"iamcredentials error: {r.text}")
+@app.get("/auth-ids/{auth_id}", response_model=AuthIdResponse)
+def get_auth_id_endpoint(auth_id: str) -> AuthIdResponse:
+    row = get_auth_id(auth_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="auth_id not found")
+    return row_to_auth_response(row)
 
-    id_token = r.json().get("token")
-    if not id_token:
-        raise HTTPException(status_code=502, detail="id_token empty")
 
-    return JSONResponse({"id_token": id_token})
+@app.post("/auth-ids/{auth_id}/enable", response_model=AuthIdResponse)
+def enable_auth_id(auth_id: str) -> AuthIdResponse:
+    updated = set_auth_id_status(auth_id, True)
+    if not updated:
+        raise HTTPException(status_code=404, detail="auth_id not found")
+    row = get_auth_id(auth_id)
+    return row_to_auth_response(row)
+
+
+@app.post("/auth-ids/{auth_id}/disable", response_model=AuthIdResponse)
+def disable_auth_id(auth_id: str) -> AuthIdResponse:
+    updated = set_auth_id_status(auth_id, False)
+    if not updated:
+        raise HTTPException(status_code=404, detail="auth_id not found")
+    row = get_auth_id(auth_id)
+    return row_to_auth_response(row)
+
+
+@app.post("/auth-ids/verify", response_model=VerifyResponse)
+def verify_auth_id(payload: VerifyRequest) -> VerifyResponse:
+    is_valid = is_auth_id_valid(payload.auth_id)
+    return VerifyResponse(is_valid=is_valid)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 fastapi==0.112.0
 uvicorn[standard]==0.30.6
-google-auth==2.34.0
-google-auth-transport-requests==2.0.0


### PR DESCRIPTION
## Summary
- replace the Google IAM token helper with an auth ID manager tailored for Cloud Run header authentication
- persist auth IDs in SQLite and expose endpoints to create, list, enable/disable, and verify them
- drop unused Google authentication dependencies from the runtime requirements

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d495b285c48332b2df5aba111fd877