### PR TITLE
Persist auth IDs in PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Broker API Guide
 
-このサービスは FastAPI で実装された認証 ID 管理 API です。Bubble などのノーコードアプリから認証 ID を取得し、Cloud Run 上の保護対象 API にリクエストする際のヘッダー認証に利用できます。
+このサービスは FastAPI で実装された認証 ID 管理 API です。Bubble などのノーコードアプリから認証 ID を取得し、Cloud Run 上の保護対象 API にリクエストする際のヘッダー認証に利用できます。発行された ID には対応する顧客 ID と有効 / 無効の状態が保存されます。
 
 ## セットアップ
 
@@ -12,13 +12,26 @@
 
    | 変数名 | 説明 | 既定値 |
    | ------ | ---- | ------ |
-   | `AUTH_DB_PATH` | 認証 ID を保持する SQLite ファイルのパス。存在しないディレクトリは自動作成されます。 | `auth_ids.db` |
+   | `DATABASE_URL` | PostgreSQL への接続文字列。例: `postgresql://postgres:<password>@<host>:5432/<database>` | （必須） |
+   | `DB_POOL_MIN_SIZE` | 接続プールの初期コネクション数。 | `1` |
+   | `DB_POOL_MAX_SIZE` | 接続プールの最大コネクション数。 | `5` |
    | `ALLOWED_ORIGINS` | CORS を許可するオリジン。カンマ区切りで指定します。Bubble のアプリドメインなどを設定してください。 | （未設定） |
 
 3. API サーバーを起動します。
    ```bash
    uvicorn main:app --host 0.0.0.0 --port 8080
    ```
+
+### Cloud SQL (PostgreSQL) との接続例
+
+Cloud SQL のインスタンスに接続する場合は、Cloud SQL Auth Proxy または Cloud Run の Cloud SQL コネクタを利用してネットワークを確立した上で、
+`DATABASE_URL` を次の形式で指定します。
+
+```bash
+export DATABASE_URL="postgresql://<user>:<password>@<proxy_host>:5432/<database>"
+```
+
+パブリック IP を利用する場合は、Cloud SQL インスタンスの IP アドレス（例: `34.180.84.255`）と作成したユーザー／データベース名を用いて接続文字列を組み立ててください。パスワードや接続名などの認証情報は Secret Manager 等で安全に管理し、直接ソースコードに書き込まないようにします。
 
 ## CORS 設定について
 
@@ -29,7 +42,7 @@
 | メソッド / パス | 説明 | リクエスト例 | 成功時レスポンス |
 | ---------------- | ---- | ------------ | ---------------- |
 | `GET /healthz` | ヘルスチェック | なし | `{ "ok": true }` |
-| `POST /auth-ids` | 認証 ID の新規発行 | `{"label": "bubble-client"}` | `{"auth_id": "...", "label": "bubble-client", "is_active": true, "created_at": "..."}` |
+| `POST /auth-ids` | 認証 ID の新規発行 | `{"customer_id": "customer-123", "label": "bubble-client"}` | `{"auth_id": "...", "customer_id": "customer-123", "label": "bubble-client", "is_active": true, "created_at": "..."}` |
 | `GET /auth-ids` | 認証 ID の一覧取得 | なし | `[{...}, ...]` |
 | `GET /auth-ids/{auth_id}` | 認証 ID の単体取得 | なし | `{...}` |
 | `POST /auth-ids/{auth_id}/enable` | 認証 ID を有効化 | なし | `{...}` |
@@ -39,7 +52,7 @@
 ## Bubble 連携例
 
 1. Bubble から認証 ID 管理画面を作成し、`POST /auth-ids` を呼び出して ID を取得します。
-2. 取得した `auth_id` を Cloud Run アプリにリクエストする際のカスタムヘッダー（例: `X-Broker-Auth-ID`）に設定します。
+2. 取得した `auth_id` と紐づく `customer_id` を Cloud Run アプリにリクエストする際のカスタムヘッダー（例: `X-Broker-Auth-ID`）に設定します。
 3. Cloud Run 側では受け取ったヘッダーを `POST /auth-ids/verify` に渡し、`is_valid` が `true` の場合にのみ処理を継続します。
 4. 利用停止が必要になった場合は Bubble から `POST /auth-ids/{auth_id}/disable`、再開する場合は `POST /auth-ids/{auth_id}/enable` を呼び出します。
 
@@ -52,4 +65,4 @@ python -m compileall main.py
 ## 備考
 
 - 認証 ID には有効期限はありません。無効化 API を利用して手動で制御してください。
-- SQLite を利用しているため、単一インスタンスでの運用を想定しています。複数インスタンスで利用する場合は Cloud SQL などの共有データベースへ移行してください。
+- すべての認証 ID は PostgreSQL に保存されるため、Cloud Run の再起動やスケールアウトを行ってもレコードは保持されます。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.112.0
 uvicorn[standard]==0.30.6
+psycopg[binary,pool]==3.1.18


### PR DESCRIPTION
## Summary
- replace the local SQLite implementation with a PostgreSQL-backed connection pool so issued IDs survive restarts
- ensure auth ID CRUD operations and timestamp formatting work with psycopg and UTC storage
- document the required DATABASE_URL configuration and Cloud SQL connection guidance

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d4a6eafcc48332b9a1e87eef7cd323