### PR TITLE
Embed default Cloud SQL connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Broker API Guide
 
-このサービスは FastAPI で実装された認証 ID 管理 API です。Bubble などのノーコードアプリから認証 ID を取得し、Cloud Run 上の保護対象 API にリクエストする際のヘッダー認証に利用できます。
+このサービスは FastAPI で実装された認証 ID 管理 API です。Bubble などのノーコードアプリから認証 ID を取得し、Cloud Run 上の保護対象 API にリクエストする際のヘッダー認証に利用できます。発行された ID には対応する顧客 ID と有効 / 無効の状態が保存されます。
 
 ## セットアップ
 
@@ -12,13 +12,26 @@
 
    | 変数名 | 説明 | 既定値 |
    | ------ | ---- | ------ |
-   | `AUTH_DB_PATH` | 認証 ID を保持する SQLite ファイルのパス。存在しないディレクトリは自動作成されます。 | `auth_ids.db` |
+| `DATABASE_URL` | PostgreSQL への接続文字列。例: `postgresql://postgres:<password>@<host>:5432/<database>` | `postgresql://postgres:#Hiro22199@34.180.84.255:5432/postgres` |
+   | `DB_POOL_MIN_SIZE` | 接続プールの初期コネクション数。 | `1` |
+   | `DB_POOL_MAX_SIZE` | 接続プールの最大コネクション数。 | `5` |
    | `ALLOWED_ORIGINS` | CORS を許可するオリジン。カンマ区切りで指定します。Bubble のアプリドメインなどを設定してください。 | （未設定） |
 
 3. API サーバーを起動します。
    ```bash
    uvicorn main:app --host 0.0.0.0 --port 8080
    ```
+
+### Cloud SQL (PostgreSQL) との接続例
+
+Cloud SQL のインスタンスに接続する場合は、Cloud SQL Auth Proxy または Cloud Run の Cloud SQL コネクタを利用してネットワークを確立した上で、
+既定で組み込まれている `postgresql://postgres:#Hiro22199@34.180.84.255:5432/postgres` を利用するか、`DATABASE_URL` を以下の形式で上書き指定します。
+
+```bash
+export DATABASE_URL="postgresql://<user>:<password>@<proxy_host>:5432/<database>"
+```
+
+パブリック IP を利用する場合は、接続先の IP アドレスと作成したユーザー／データベース名を用いて接続文字列を組み立てます。
 
 ## CORS 設定について
 
@@ -29,7 +42,7 @@
 | メソッド / パス | 説明 | リクエスト例 | 成功時レスポンス |
 | ---------------- | ---- | ------------ | ---------------- |
 | `GET /healthz` | ヘルスチェック | なし | `{ "ok": true }` |
-| `POST /auth-ids` | 認証 ID の新規発行 | `{"label": "bubble-client"}` | `{"auth_id": "...", "label": "bubble-client", "is_active": true, "created_at": "..."}` |
+| `POST /auth-ids` | 認証 ID の新規発行 | `{"customer_id": "customer-123", "label": "bubble-client"}` | `{"auth_id": "...", "customer_id": "customer-123", "label": "bubble-client", "is_active": true, "created_at": "..."}` |
 | `GET /auth-ids` | 認証 ID の一覧取得 | なし | `[{...}, ...]` |
 | `GET /auth-ids/{auth_id}` | 認証 ID の単体取得 | なし | `{...}` |
 | `POST /auth-ids/{auth_id}/enable` | 認証 ID を有効化 | なし | `{...}` |
@@ -39,7 +52,7 @@
 ## Bubble 連携例
 
 1. Bubble から認証 ID 管理画面を作成し、`POST /auth-ids` を呼び出して ID を取得します。
-2. 取得した `auth_id` を Cloud Run アプリにリクエストする際のカスタムヘッダー（例: `X-Broker-Auth-ID`）に設定します。
+2. 取得した `auth_id` と紐づく `customer_id` を Cloud Run アプリにリクエストする際のカスタムヘッダー（例: `X-Broker-Auth-ID`）に設定します。
 3. Cloud Run 側では受け取ったヘッダーを `POST /auth-ids/verify` に渡し、`is_valid` が `true` の場合にのみ処理を継続します。
 4. 利用停止が必要になった場合は Bubble から `POST /auth-ids/{auth_id}/disable`、再開する場合は `POST /auth-ids/{auth_id}/enable` を呼び出します。
 
@@ -52,4 +65,4 @@ python -m compileall main.py
 ## 備考
 
 - 認証 ID には有効期限はありません。無効化 API を利用して手動で制御してください。
-- SQLite を利用しているため、単一インスタンスでの運用を想定しています。複数インスタンスで利用する場合は Cloud SQL などの共有データベースへ移行してください。
+- すべての認証 ID は PostgreSQL に保存されるため、Cloud Run の再起動やスケールアウトを行ってもレコードは保持されます。

--- a/main.py
+++ b/main.py
@@ -1,80 +1,134 @@
 import os
 import secrets
-import sqlite3
-from datetime import datetime
-from typing import List, Optional
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any, Generator, List, Mapping, Optional
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
+from psycopg import Connection
+from psycopg.rows import dict_row
+from psycopg_pool import ConnectionPool
 
-DB_PATH = os.getenv("AUTH_DB_PATH", "auth_ids.db")
+DEFAULT_DATABASE_URL = (
+    "postgresql://postgres:#Hiro22199@34.180.84.255:5432/postgres"
+)
+DATABASE_URL = os.getenv("DATABASE_URL") or DEFAULT_DATABASE_URL
+POOL_MIN_SIZE = int(os.getenv("DB_POOL_MIN_SIZE", "1"))
+POOL_MAX_SIZE = int(os.getenv("DB_POOL_MAX_SIZE", "5"))
 ALLOWED_ORIGINS = list(
     filter(None, (origin.strip() for origin in os.getenv("ALLOWED_ORIGINS", "").split(",")))
 )
 
 
+if not DATABASE_URL:
+    raise RuntimeError(
+        "DATABASE_URL environment variable is required to persist auth IDs in PostgreSQL."
+    )
+
+
+connection_pool: Optional[ConnectionPool] = None
+
+
+def get_connection_pool() -> ConnectionPool:
+    global connection_pool
+    if connection_pool is None:
+        connection_pool = ConnectionPool(
+            conninfo=DATABASE_URL,
+            min_size=POOL_MIN_SIZE,
+            max_size=POOL_MAX_SIZE,
+        )
+    return connection_pool
+
+
+@contextmanager
+def get_cursor() -> Generator[tuple[Connection, Any], None, None]:
+    pool = get_connection_pool()
+    with pool.connection() as conn:
+        with conn.cursor(row_factory=dict_row) as cur:
+            try:
+                yield conn, cur
+            except Exception:
+                conn.rollback()
+                raise
+
+
 def init_db() -> None:
-    directory = os.path.dirname(DB_PATH)
-    if directory:
-        os.makedirs(directory, exist_ok=True)
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.execute(
+    with get_cursor() as (conn, cur):
+        cur.execute(
             """
             CREATE TABLE IF NOT EXISTS auth_ids (
                 id TEXT PRIMARY KEY,
+                customer_id TEXT,
                 label TEXT,
-                is_active INTEGER NOT NULL,
-                created_at TEXT NOT NULL
+                is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
             )
             """
         )
+        conn.commit()
 
 
-def create_auth_id(label: Optional[str]) -> str:
+def create_auth_id(customer_id: str, label: Optional[str]) -> str:
     auth_id = secrets.token_urlsafe(32)
-    created_at = datetime.utcnow().isoformat() + "Z"
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.execute(
-            "INSERT INTO auth_ids (id, label, is_active, created_at) VALUES (?, ?, ?, ?)",
-            (auth_id, label, 1, created_at),
+    created_at = datetime.now(timezone.utc)
+    with get_cursor() as (conn, cur):
+        cur.execute(
+            """
+            INSERT INTO auth_ids (id, customer_id, label, is_active, created_at)
+            VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT (id) DO NOTHING
+            """,
+            (auth_id, customer_id, label, True, created_at),
         )
+        conn.commit()
     return auth_id
 
 
-def list_auth_ids() -> List[sqlite3.Row]:
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.row_factory = sqlite3.Row
-        rows = conn.execute(
-            "SELECT id, label, is_active, created_at FROM auth_ids ORDER BY created_at DESC"
-        ).fetchall()
+def list_auth_ids() -> List[Mapping[str, Any]]:
+    with get_cursor() as (conn, cur):
+        cur.execute(
+            """
+            SELECT id, customer_id, label, is_active, created_at
+            FROM auth_ids
+            ORDER BY created_at DESC
+            """
+        )
+        rows = cur.fetchall()
     return rows
 
 
-def get_auth_id(auth_id: str) -> Optional[sqlite3.Row]:
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.row_factory = sqlite3.Row
-        row = conn.execute(
-            "SELECT id, label, is_active, created_at FROM auth_ids WHERE id = ?",
+def get_auth_id(auth_id: str) -> Optional[Mapping[str, Any]]:
+    with get_cursor() as (conn, cur):
+        cur.execute(
+            """
+            SELECT id, customer_id, label, is_active, created_at
+            FROM auth_ids
+            WHERE id = %s
+            """,
             (auth_id,),
-        ).fetchone()
+        )
+        row = cur.fetchone()
     return row
 
 
 def set_auth_id_status(auth_id: str, is_active: bool) -> bool:
-    with sqlite3.connect(DB_PATH) as conn:
-        cur = conn.execute(
-            "UPDATE auth_ids SET is_active = ? WHERE id = ?",
-            (1 if is_active else 0, auth_id),
+    with get_cursor() as (conn, cur):
+        cur.execute(
+            "UPDATE auth_ids SET is_active = %s WHERE id = %s",
+            (is_active, auth_id),
         )
-        return cur.rowcount > 0
+        updated = cur.rowcount > 0
+        conn.commit()
+        return updated
 
 
 def is_auth_id_valid(auth_id: str) -> bool:
-    with sqlite3.connect(DB_PATH) as conn:
-        cur = conn.execute(
-            "SELECT 1 FROM auth_ids WHERE id = ? AND is_active = 1",
+    with get_cursor() as (_, cur):
+        cur.execute(
+            "SELECT 1 FROM auth_ids WHERE id = %s AND is_active = TRUE",
             (auth_id,),
         )
         return cur.fetchone() is not None
@@ -82,12 +136,14 @@ def is_auth_id_valid(auth_id: str) -> bool:
 
 class AuthIdResponse(BaseModel):
     auth_id: str
+    customer_id: Optional[str]
     label: Optional[str]
     is_active: bool
     created_at: str
 
 
 class CreateAuthIdRequest(BaseModel):
+    customer_id: str = Field(..., min_length=1)
     label: Optional[str] = None
 
 
@@ -99,12 +155,21 @@ class VerifyResponse(BaseModel):
     is_valid: bool
 
 
-def row_to_auth_response(row: sqlite3.Row) -> AuthIdResponse:
+def to_utc_isoformat(value: Any) -> str:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def row_to_auth_response(row: Mapping[str, Any]) -> AuthIdResponse:
     return AuthIdResponse(
         auth_id=row["id"],
-        label=row["label"],
+        customer_id=row.get("customer_id"),
+        label=row.get("label"),
         is_active=bool(row["is_active"]),
-        created_at=row["created_at"],
+        created_at=to_utc_isoformat(row["created_at"]),
     )
 
 
@@ -132,7 +197,7 @@ def healthz() -> dict:
 
 @app.post("/auth-ids", response_model=AuthIdResponse)
 def issue_auth_id(payload: CreateAuthIdRequest) -> AuthIdResponse:
-    auth_id = create_auth_id(payload.label)
+    auth_id = create_auth_id(payload.customer_id, payload.label)
     row = get_auth_id(auth_id)
     return row_to_auth_response(row)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.112.0
 uvicorn[standard]==0.30.6
+psycopg[binary,pool]==3.1.18


### PR DESCRIPTION
## Summary
- default DATABASE_URL to the provided Cloud SQL connection string so the API links to the shared PostgreSQL instance without extra configuration
- document the baked-in connection string and how to override it when pointing at a different database

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d4a6eafcc48332b9a1e87eef7cd323