### PR TITLE
Allow local SQLite fallback when PostgreSQL is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Broker API Guide
 
-このサービスは FastAPI で実装された認証 ID 管理 API です。Bubble などのノーコードアプリから認証 ID を取得し、Cloud Run 上の保護対象 API にリクエストする際のヘッダー認証に利用できます。
+このサービスは FastAPI で実装された認証 ID 管理 API です。Bubble などのノーコードアプリから認証 ID を取得し、Cloud Run 上の保護対象 API にリクエストする際のヘッダー認証に利用できます。発行された ID には対応する顧客 ID と有効 / 無効の状態が保存されます。
 
 ## セットアップ
 
@@ -12,13 +12,27 @@
 
    | 変数名 | 説明 | 既定値 |
    | ------ | ---- | ------ |
-   | `AUTH_DB_PATH` | 認証 ID を保持する SQLite ファイルのパス。存在しないディレクトリは自動作成されます。 | `auth_ids.db` |
+| `DATABASE_URL` | Cloud SQL などの PostgreSQL への接続文字列。例: `postgresql://postgres:<password>@<host>:5432/<database>` | （未設定） |
+   | `DB_POOL_MIN_SIZE` | PostgreSQL 利用時の接続プール初期コネクション数。 | `1` |
+   | `DB_POOL_MAX_SIZE` | PostgreSQL 利用時の接続プール最大コネクション数。 | `5` |
+   | `AUTH_DB_PATH` | PostgreSQL を指定しない場合に利用する SQLite ファイルのパス。 | `auth_ids.db` |
    | `ALLOWED_ORIGINS` | CORS を許可するオリジン。カンマ区切りで指定します。Bubble のアプリドメインなどを設定してください。 | （未設定） |
 
 3. API サーバーを起動します。
    ```bash
    uvicorn main:app --host 0.0.0.0 --port 8080
    ```
+
+### Cloud SQL (PostgreSQL) との接続例
+
+Cloud SQL のインスタンスに接続する場合は、Cloud SQL Auth Proxy または Cloud Run の Cloud SQL コネクタを利用してネットワークを確立した上で、
+`DATABASE_URL` を以下の形式で設定します。
+
+```bash
+export DATABASE_URL="postgresql://<user>:<password>@<proxy_host>:5432/<database>"
+```
+
+パブリック IP を利用する場合は、接続先の IP アドレスと作成したユーザー／データベース名を用いて接続文字列を組み立てます。Cloud Run から直接アクセスする場合は、Cloud SQL Auth Proxy のデプロイや Cloud SQL コネクタの設定など、ネットワーク経路の確立が必要です。
 
 ## CORS 設定について
 
@@ -29,7 +43,7 @@
 | メソッド / パス | 説明 | リクエスト例 | 成功時レスポンス |
 | ---------------- | ---- | ------------ | ---------------- |
 | `GET /healthz` | ヘルスチェック | なし | `{ "ok": true }` |
-| `POST /auth-ids` | 認証 ID の新規発行 | `{"label": "bubble-client"}` | `{"auth_id": "...", "label": "bubble-client", "is_active": true, "created_at": "..."}` |
+| `POST /auth-ids` | 認証 ID の新規発行 | `{"customer_id": "customer-123", "label": "bubble-client"}` | `{"auth_id": "...", "customer_id": "customer-123", "label": "bubble-client", "is_active": true, "created_at": "..."}` |
 | `GET /auth-ids` | 認証 ID の一覧取得 | なし | `[{...}, ...]` |
 | `GET /auth-ids/{auth_id}` | 認証 ID の単体取得 | なし | `{...}` |
 | `POST /auth-ids/{auth_id}/enable` | 認証 ID を有効化 | なし | `{...}` |
@@ -39,7 +53,7 @@
 ## Bubble 連携例
 
 1. Bubble から認証 ID 管理画面を作成し、`POST /auth-ids` を呼び出して ID を取得します。
-2. 取得した `auth_id` を Cloud Run アプリにリクエストする際のカスタムヘッダー（例: `X-Broker-Auth-ID`）に設定します。
+2. 取得した `auth_id` と紐づく `customer_id` を Cloud Run アプリにリクエストする際のカスタムヘッダー（例: `X-Broker-Auth-ID`）に設定します。
 3. Cloud Run 側では受け取ったヘッダーを `POST /auth-ids/verify` に渡し、`is_valid` が `true` の場合にのみ処理を継続します。
 4. 利用停止が必要になった場合は Bubble から `POST /auth-ids/{auth_id}/disable`、再開する場合は `POST /auth-ids/{auth_id}/enable` を呼び出します。
 
@@ -52,4 +66,4 @@ python -m compileall main.py
 ## 備考
 
 - 認証 ID には有効期限はありません。無効化 API を利用して手動で制御してください。
-- SQLite を利用しているため、単一インスタンスでの運用を想定しています。複数インスタンスで利用する場合は Cloud SQL などの共有データベースへ移行してください。
+- `DATABASE_URL` を設定すると認証 ID は PostgreSQL に保存され、Cloud Run の再起動やスケールアウトを行ってもレコードは保持されます。環境変数を設定しない場合はローカルの SQLite ファイルに保存されるため、Cloud Run の再デプロイ時などに消失します。

--- a/main.py
+++ b/main.py
@@ -1,93 +1,278 @@
 import os
 import secrets
 import sqlite3
-from datetime import datetime
-from typing import List, Optional
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any, Generator, List, Mapping, Optional, Protocol
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 
+from psycopg.rows import dict_row
+from psycopg_pool import ConnectionPool
 
-DB_PATH = os.getenv("AUTH_DB_PATH", "auth_ids.db")
+DATABASE_URL = os.getenv("DATABASE_URL")
+POOL_MIN_SIZE = int(os.getenv("DB_POOL_MIN_SIZE", "1"))
+POOL_MAX_SIZE = int(os.getenv("DB_POOL_MAX_SIZE", "5"))
+AUTH_DB_PATH = os.getenv("AUTH_DB_PATH", "auth_ids.db")
 ALLOWED_ORIGINS = list(
     filter(None, (origin.strip() for origin in os.getenv("ALLOWED_ORIGINS", "").split(",")))
 )
 
 
-def init_db() -> None:
-    directory = os.path.dirname(DB_PATH)
-    if directory:
-        os.makedirs(directory, exist_ok=True)
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS auth_ids (
-                id TEXT PRIMARY KEY,
-                label TEXT,
-                is_active INTEGER NOT NULL,
-                created_at TEXT NOT NULL
+class AuthRepository(Protocol):
+    def init_db(self) -> None:
+        ...
+
+    def issue_auth_id(self, customer_id: str, label: Optional[str]) -> Mapping[str, Any]:
+        ...
+
+    def list_auth_ids(self) -> List[Mapping[str, Any]]:
+        ...
+
+    def get_auth_id(self, auth_id: str) -> Optional[Mapping[str, Any]]:
+        ...
+
+    def update_auth_id_status(
+        self, auth_id: str, is_active: bool
+    ) -> Optional[Mapping[str, Any]]:
+        ...
+
+    def is_auth_id_valid(self, auth_id: str) -> bool:
+        ...
+
+    def close(self) -> None:
+        ...
+
+
+class PostgresRepository:
+    def __init__(self, conninfo: str, min_size: int, max_size: int) -> None:
+        self._conninfo = conninfo
+        self._min_size = min_size
+        self._max_size = max_size
+        self._pool: Optional[ConnectionPool] = None
+
+    def _get_pool(self) -> ConnectionPool:
+        if self._pool is None:
+            self._pool = ConnectionPool(
+                conninfo=self._conninfo,
+                min_size=self._min_size,
+                max_size=self._max_size,
             )
-            """
-        )
+        return self._pool
+
+    @contextmanager
+    def _get_cursor(self) -> Generator[tuple[Any, Any], None, None]:
+        pool = self._get_pool()
+        with pool.connection() as conn:
+            with conn.cursor(row_factory=dict_row) as cur:
+                yield conn, cur
+
+    def init_db(self) -> None:
+        with self._get_cursor() as (conn, cur):
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS auth_ids (
+                    id TEXT PRIMARY KEY,
+                    customer_id TEXT,
+                    label TEXT,
+                    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                )
+                """
+            )
+            conn.commit()
+
+    def issue_auth_id(self, customer_id: str, label: Optional[str]) -> Mapping[str, Any]:
+        auth_id = secrets.token_urlsafe(32)
+        created_at = datetime.now(timezone.utc)
+        with self._get_cursor() as (conn, cur):
+            cur.execute(
+                """
+                INSERT INTO auth_ids (id, customer_id, label, is_active, created_at)
+                VALUES (%s, %s, %s, %s, %s)
+                RETURNING id, customer_id, label, is_active, created_at
+                """,
+                (auth_id, customer_id, label, True, created_at),
+            )
+            row = cur.fetchone()
+            conn.commit()
+        return row
+
+    def list_auth_ids(self) -> List[Mapping[str, Any]]:
+        with self._get_cursor() as (_, cur):
+            cur.execute(
+                """
+                SELECT id, customer_id, label, is_active, created_at
+                FROM auth_ids
+                ORDER BY created_at DESC
+                """
+            )
+            rows = cur.fetchall()
+        return rows
+
+    def get_auth_id(self, auth_id: str) -> Optional[Mapping[str, Any]]:
+        with self._get_cursor() as (_, cur):
+            cur.execute(
+                """
+                SELECT id, customer_id, label, is_active, created_at
+                FROM auth_ids
+                WHERE id = %s
+                """,
+                (auth_id,),
+            )
+            row = cur.fetchone()
+        return row
+
+    def update_auth_id_status(
+        self, auth_id: str, is_active: bool
+    ) -> Optional[Mapping[str, Any]]:
+        with self._get_cursor() as (conn, cur):
+            cur.execute(
+                """
+                UPDATE auth_ids
+                SET is_active = %s
+                WHERE id = %s
+                RETURNING id, customer_id, label, is_active, created_at
+                """,
+                (is_active, auth_id),
+            )
+            row = cur.fetchone()
+            conn.commit()
+        return row
+
+    def is_auth_id_valid(self, auth_id: str) -> bool:
+        with self._get_cursor() as (_, cur):
+            cur.execute(
+                "SELECT 1 FROM auth_ids WHERE id = %s AND is_active = TRUE",
+                (auth_id,),
+            )
+            return cur.fetchone() is not None
+
+    def close(self) -> None:
+        if self._pool is not None:
+            self._pool.close()
+            self._pool = None
 
 
-def create_auth_id(label: Optional[str]) -> str:
-    auth_id = secrets.token_urlsafe(32)
-    created_at = datetime.utcnow().isoformat() + "Z"
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.execute(
-            "INSERT INTO auth_ids (id, label, is_active, created_at) VALUES (?, ?, ?, ?)",
-            (auth_id, label, 1, created_at),
-        )
-    return auth_id
+class SQLiteRepository:
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
 
-
-def list_auth_ids() -> List[sqlite3.Row]:
-    with sqlite3.connect(DB_PATH) as conn:
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
         conn.row_factory = sqlite3.Row
-        rows = conn.execute(
-            "SELECT id, label, is_active, created_at FROM auth_ids ORDER BY created_at DESC"
-        ).fetchall()
-    return rows
+        return conn
 
+    def init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS auth_ids (
+                    id TEXT PRIMARY KEY,
+                    customer_id TEXT,
+                    label TEXT,
+                    is_active INTEGER NOT NULL DEFAULT 1,
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.commit()
 
-def get_auth_id(auth_id: str) -> Optional[sqlite3.Row]:
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.row_factory = sqlite3.Row
-        row = conn.execute(
-            "SELECT id, label, is_active, created_at FROM auth_ids WHERE id = ?",
-            (auth_id,),
-        ).fetchone()
-    return row
+    def issue_auth_id(self, customer_id: str, label: Optional[str]) -> Mapping[str, Any]:
+        auth_id = secrets.token_urlsafe(32)
+        created_at = datetime.now(timezone.utc).isoformat()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO auth_ids (id, customer_id, label, is_active, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (auth_id, customer_id, label, 1, created_at),
+            )
+            cursor = conn.execute(
+                """
+                SELECT id, customer_id, label, is_active, created_at
+                FROM auth_ids
+                WHERE id = ?
+                """,
+                (auth_id,),
+            )
+            row = cursor.fetchone()
+            conn.commit()
+        return dict(row) if row else {}
 
+    def list_auth_ids(self) -> List[Mapping[str, Any]]:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT id, customer_id, label, is_active, created_at
+                FROM auth_ids
+                ORDER BY created_at DESC
+                """
+            )
+            rows = cursor.fetchall()
+        return [dict(row) for row in rows]
 
-def set_auth_id_status(auth_id: str, is_active: bool) -> bool:
-    with sqlite3.connect(DB_PATH) as conn:
-        cur = conn.execute(
-            "UPDATE auth_ids SET is_active = ? WHERE id = ?",
-            (1 if is_active else 0, auth_id),
-        )
-        return cur.rowcount > 0
+    def get_auth_id(self, auth_id: str) -> Optional[Mapping[str, Any]]:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                """
+                SELECT id, customer_id, label, is_active, created_at
+                FROM auth_ids
+                WHERE id = ?
+                """,
+                (auth_id,),
+            )
+            row = cursor.fetchone()
+        return dict(row) if row else None
 
+    def update_auth_id_status(
+        self, auth_id: str, is_active: bool
+    ) -> Optional[Mapping[str, Any]]:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "UPDATE auth_ids SET is_active = ? WHERE id = ?",
+                (1 if is_active else 0, auth_id),
+            )
+            if cursor.rowcount == 0:
+                conn.commit()
+                return None
+            row_cursor = conn.execute(
+                """
+                SELECT id, customer_id, label, is_active, created_at
+                FROM auth_ids
+                WHERE id = ?
+                """,
+                (auth_id,),
+            )
+            row = row_cursor.fetchone()
+            conn.commit()
+        return dict(row) if row else None
 
-def is_auth_id_valid(auth_id: str) -> bool:
-    with sqlite3.connect(DB_PATH) as conn:
-        cur = conn.execute(
-            "SELECT 1 FROM auth_ids WHERE id = ? AND is_active = 1",
-            (auth_id,),
-        )
-        return cur.fetchone() is not None
+    def is_auth_id_valid(self, auth_id: str) -> bool:
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "SELECT 1 FROM auth_ids WHERE id = ? AND is_active = 1",
+                (auth_id,),
+            )
+            return cursor.fetchone() is not None
+
+    def close(self) -> None:
+        return None
 
 
 class AuthIdResponse(BaseModel):
     auth_id: str
+    customer_id: Optional[str]
     label: Optional[str]
     is_active: bool
     created_at: str
 
 
 class CreateAuthIdRequest(BaseModel):
+    customer_id: str = Field(..., min_length=1)
     label: Optional[str] = None
 
 
@@ -99,13 +284,30 @@ class VerifyResponse(BaseModel):
     is_valid: bool
 
 
-def row_to_auth_response(row: sqlite3.Row) -> AuthIdResponse:
+def to_utc_isoformat(value: Any) -> str:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return str(value)
+
+
+def row_to_auth_response(row: Mapping[str, Any]) -> AuthIdResponse:
     return AuthIdResponse(
         auth_id=row["id"],
-        label=row["label"],
+        customer_id=row.get("customer_id"),
+        label=row.get("label"),
         is_active=bool(row["is_active"]),
-        created_at=row["created_at"],
+        created_at=to_utc_isoformat(row["created_at"]),
     )
+
+
+if DATABASE_URL:
+    repository: AuthRepository = PostgresRepository(
+        DATABASE_URL, POOL_MIN_SIZE, POOL_MAX_SIZE
+    )
+else:
+    repository = SQLiteRepository(AUTH_DB_PATH)
 
 
 app = FastAPI()
@@ -122,7 +324,12 @@ if ALLOWED_ORIGINS:
 
 @app.on_event("startup")
 def startup_event() -> None:
-    init_db()
+    repository.init_db()
+
+
+@app.on_event("shutdown")
+def shutdown_event() -> None:
+    repository.close()
 
 
 @app.get("/healthz")
@@ -132,20 +339,19 @@ def healthz() -> dict:
 
 @app.post("/auth-ids", response_model=AuthIdResponse)
 def issue_auth_id(payload: CreateAuthIdRequest) -> AuthIdResponse:
-    auth_id = create_auth_id(payload.label)
-    row = get_auth_id(auth_id)
+    row = repository.issue_auth_id(payload.customer_id, payload.label)
     return row_to_auth_response(row)
 
 
 @app.get("/auth-ids", response_model=List[AuthIdResponse])
 def list_auth_id_endpoint() -> List[AuthIdResponse]:
-    rows = list_auth_ids()
+    rows = repository.list_auth_ids()
     return [row_to_auth_response(row) for row in rows]
 
 
 @app.get("/auth-ids/{auth_id}", response_model=AuthIdResponse)
 def get_auth_id_endpoint(auth_id: str) -> AuthIdResponse:
-    row = get_auth_id(auth_id)
+    row = repository.get_auth_id(auth_id)
     if not row:
         raise HTTPException(status_code=404, detail="auth_id not found")
     return row_to_auth_response(row)
@@ -153,24 +359,22 @@ def get_auth_id_endpoint(auth_id: str) -> AuthIdResponse:
 
 @app.post("/auth-ids/{auth_id}/enable", response_model=AuthIdResponse)
 def enable_auth_id(auth_id: str) -> AuthIdResponse:
-    updated = set_auth_id_status(auth_id, True)
-    if not updated:
+    row = repository.update_auth_id_status(auth_id, True)
+    if not row:
         raise HTTPException(status_code=404, detail="auth_id not found")
-    row = get_auth_id(auth_id)
     return row_to_auth_response(row)
 
 
 @app.post("/auth-ids/{auth_id}/disable", response_model=AuthIdResponse)
 def disable_auth_id(auth_id: str) -> AuthIdResponse:
-    updated = set_auth_id_status(auth_id, False)
-    if not updated:
+    row = repository.update_auth_id_status(auth_id, False)
+    if not row:
         raise HTTPException(status_code=404, detail="auth_id not found")
-    row = get_auth_id(auth_id)
     return row_to_auth_response(row)
 
 
 @app.post("/auth-ids/verify", response_model=VerifyResponse)
 def verify_auth_id(payload: VerifyRequest) -> VerifyResponse:
-    is_valid = is_auth_id_valid(payload.auth_id)
+    is_valid = repository.is_auth_id_valid(payload.auth_id)
     return VerifyResponse(is_valid=is_valid)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.112.0
 uvicorn[standard]==0.30.6
+psycopg[binary,pool]==3.1.18


### PR DESCRIPTION
## Summary
- replace the hard-coded Cloud SQL connection string with a repository layer that uses PostgreSQL when `DATABASE_URL` is provided and falls back to SQLite otherwise so the service can start without external configuration
- add a shutdown hook for the PostgreSQL connection pool and reuse the repository for all CRUD operations
- document the new configuration options, including the optional SQLite file path and the requirement to configure Cloud SQL connectivity for persistence

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d4a6eafcc48332b9a1e87eef7cd323